### PR TITLE
App: user: register: Support MIMEMultipart to attach both formats of HTML and plaintext to the activation E-mail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,92 @@
+# Database files
+data.db
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject


### PR DESCRIPTION
It is more convenient for users having trouble in reading HTMLed E-mails to see a plaintext message as an alternative to `<a href="msks://[fc00::4e2b]:23333/user/activate/20011/WOW_SUCH_UNREADABLE_CODE_un_Misaka_sajt_dogeli">such unreadable code</a>`.

New activation E-mails should include both HTML and plaintext versions of message, and users should be able to choose which format to be displayed if they use an E-mail client smart enough.
